### PR TITLE
Fix typo in the Learning Hub

### DIFF
--- a/content/page/learninghub/The EASE Learning Hub/index.md
+++ b/content/page/learninghub/The EASE Learning Hub/index.md
@@ -1,5 +1,5 @@
 ---
-title: "The Ease Learning Hub"
+title: "The EASE Learning Hub"
 date: 2012-01-27T14:33:42-04:00
 subtitle: ""
 tags: ["Research", "Teaching", "Education"]


### PR DESCRIPTION
Replaced Ease in title of "The Ease Learning Hub"
with capital EASE.