### PR TITLE
Add lab for Systematic Review on Metacognitive Tracing

### DIFF
--- a/content/page/labs/Systematic Review on Metacognitive Tracing/buttons.json
+++ b/content/page/labs/Systematic Review on Metacognitive Tracing/buttons.json
@@ -1,0 +1,11 @@
+{
+  "options": {},
+  "actions": [
+    {
+      "name": "Interactive Visualizations",
+      "value": "graphs",
+      "description": "Go to the website with the interactive visualizations.",
+      "url": "https://dml.uni-bremen.de/ease/review/"
+    }
+  ]
+}

--- a/content/page/labs/Systematic Review on Metacognitive Tracing/index.md
+++ b/content/page/labs/Systematic Review on Metacognitive Tracing/index.md
@@ -1,0 +1,34 @@
+---
+title: "Systematic Review on Metacognitive Tracing"
+date: 2025-02-23T00:00:00+01:00
+subtitle: ""
+tags: ["Research", "Metacognition", "Review"]
+dropCap: false
+displayInMenu: false
+displayInList: true
+draft: false
+on_homepage: false
+resources:
+- name: ActionButtons
+  src: "buttons.json"
+---
+
+The Metacognition Lab is an interactive online platform designed as a companion to our systematic review of Computational Metacognitive Architectures (CMAs). In this lab, you can explore a range of dynamic visualizations that bring the paper’s analyses to life, offering an in-depth look at how CMAs handle metacognitive experiences. Drawing on data from 36 identified systems, the lab allows you to navigate through the diverse design choices used to model, store, and process introspective information.
+
+
+Upon entering the lab, you can select specific visualizations—from interactive network graphs depicting theoretical lineages and co-authorship data to grid charts that map symbolic versus sub-symbolic representations. Detailed tooltips and filtering options enable you to tailor your exploration: for instance, you can focus on certain systems, search for specific authors. By hovering over data points, you can retrieve contextual details such as underlying data sources.
+
+
+Ultimately, The Metacognition Lab fosters a deeper understanding of the review’s findings by encouraging hands-on interaction with the data. Whether you are a researcher, educator, or practitioner, this environment provides a unique gateway to uncover patterns, pose new questions, and glean insights into the rapidly evolving field of metacognitive architectures.
+
+
+{{<action_form data="ActionButtons">}}
+
+<div class="hidde-after-preview">
+  For Detailed information click
+  <a class="btn btn-success" target="_blank" href="survey-on-metacognitive-tracing"><b>here!</b></a>
+</div>
+
+<!--more-->
+
+[comment]: <> (without the <!--more-->, only the first paragraph is shown on the page)


### PR DESCRIPTION
Adds a lab entry "Systematic Review on Metacognitive Tracing" for the upcoming review paper. The [website](https://dml.uni-bremen.de/ease/review/) to which the button forwards will be online from the 01.03.2025.